### PR TITLE
Prevent shortcode inserter from wrapping to the start of a post

### DIFF
--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -52,9 +52,9 @@ function scaip_insert_shortcode($content = '') {
 		$last_position = stripos( $content, $paragraph_end, $last_position +1 ) +3; // what does the 3 mean?
 		$paragraph_positions[] = $last_position;
 		// Can this be simplified to just go off of: ?
-		//     $paragraph_positions[] = $last_position + 4 
+		//     $paragraph_positions[] = $last_position + 4
 		//
-		// Maybe? 1 + 3 is the length of '</p>', and putting it in the offset argument for strpos() would 
+		// Maybe? 1 + 3 is the length of '</p>', and putting it in the offset argument for strpos() would
 		// make the strpos start looking for the opening '<' after the ending '>' instead of in the middle of the '</p>'.
 		// Or it might not. Not going to mess with this today.
 	}
@@ -65,17 +65,29 @@ function scaip_insert_shortcode($content = '') {
 
 		// How many shortcodes have been added;
 		$n = 1;
+		
+		// Safety check number: stores the position of the last insertion
+		$previous_position = 0;
 
 		while ( $i <= sizeof($paragraph_positions) && $n <= $scaip_repetitions ) {
 			// Modulo math to only output shortcode after $scaip_period closing paragraph tags.
 			// +1 because of zero-based indexing
-			if ( ($i + 1 ) % $scaip_period == 0 ) {
+			if ( ($i + 1 ) % $scaip_period == 0 && isset( $paragraph_positions[$i] ) ) {
 
-				// make a shortcode, then increment number of shortcodes that have been added to the document.
+				// make a shortcode using the number of the shorcode that will be added.
 				$shortcode = "[ad number=$n ]";
-				$n++;
 
-				$content = substr_replace($content, $shortcode, $paragraph_positions[$i] + 1, 0);
+				$position = $paragraph_positions[$i] + 1;
+
+				// Safety check:
+				// If the position we're adding the shortcode is at a lower point in the story than the position we're adding,
+				// Then something has gone wrong and we should insert no more shortcodes.
+				if ( $position > $previous_position ) {
+					$content = substr_replace($content, $shortcode, $paragraph_positions[$i] + 1, 0);
+					
+					// Increase the saved last position.
+					$previous_position = $position;
+				}
 
 				// Increase the position of later shortcodes by the length of the current shortcode
 				foreach ( $paragraph_positions as $j => $pp ) {
@@ -83,6 +95,9 @@ function scaip_insert_shortcode($content = '') {
 						$paragraph_positions[$j] = $pp + strlen($shortcode);
 					}
 				}
+
+				// Increment number of shortcodes added to the post
+				$n++;
 			}
 
 			$i++;

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -69,6 +69,7 @@ function scaip_insert_shortcode($content = '') {
 		// Safety check number: stores the position of the last insertion
 		$previous_position = 0;
 
+		$i = 0;
 		while ( $i <= sizeof($paragraph_positions) && $n <= $scaip_repetitions ) {
 			// Modulo math to only output shortcode after $scaip_period closing paragraph tags.
 			// +1 because of zero-based indexing

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -70,7 +70,7 @@ function scaip_insert_shortcode($content = '') {
 		$previous_position = 0;
 
 		$i = 0;
-		while ( $i <= sizeof($paragraph_positions) && $n <= $scaip_repetitions ) {
+		while ( $i < sizeof($paragraph_positions) && $n <= $scaip_repetitions ) {
 			// Modulo math to only output shortcode after $scaip_period closing paragraph tags.
 			// +1 because of zero-based indexing
 			if ( ($i + 1 ) % $scaip_period == 0 && isset( $paragraph_positions[$i] ) ) {

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -85,9 +85,12 @@ function scaip_insert_shortcode($content = '') {
 				// Then something has gone wrong and we should insert no more shortcodes.
 				if ( $position > $previous_position ) {
 					$content = substr_replace($content, $shortcode, $paragraph_positions[$i] + 1, 0);
-					
+
 					// Increase the saved last position.
 					$previous_position = $position;
+
+					// Increment number of shortcodes added to the post
+					$n++;
 				}
 
 				// Increase the position of later shortcodes by the length of the current shortcode
@@ -96,9 +99,6 @@ function scaip_insert_shortcode($content = '') {
 						$paragraph_positions[$j] = $pp + strlen($shortcode);
 					}
 				}
-
-				// Increment number of shortcodes added to the post
-				$n++;
 			}
 
 			$i++;


### PR DESCRIPTION
## Changes

- Checks that the paragraph position being inserted in is set in the array of paragraph positions
- Checks that the paragraph position being inserted in is greater than the last paragraph position that was set in
- Defines the variable `$i` used in the shortcode inserter `while` loop to take care of an undefined variable notice (#17)

## Why

`$paragraph_positions[$i]` wasn't set when `$i` was equal to `count($paragraph_positions)` **and** `($i + 1 ) % $scaip_period == 0`.

This is because `$paragraph_positions` is zero-indexed and `count(` starts counting from `1`, so it was an off-by-one error.
