### PR TITLE
Add filter to turn off insertion; split insertion functionality across two functions.

### DIFF
--- a/docs/developers-shortcode-docs.md
+++ b/docs/developers-shortcode-docs.md
@@ -54,3 +54,10 @@ function scaip_test_inserter_disabler( $whether, $content, $queried_object ) {
 	return $whether;
 }
 add_filter( 'scaip_whether_insert', 'scaip_test_inserter_disabler', 10, 3 );
+```
+
+### Custom sidebar inserters
+
+First, disable the normal inserter as described above.
+
+Then, create a function that inserts the `[ad number=$n]` shortcode in your `post_content` where you want it to appears, where `n` is an integer between `1` and the value of `get_option( 'scaip_settings_repetitions' )`.

--- a/docs/developers-shortcode-docs.md
+++ b/docs/developers-shortcode-docs.md
@@ -35,4 +35,22 @@ add_action('scaip_shortcode', 'scaip_test_function');
 
 ### Disable the normal shortcodes
 
-Write a hook that hooks the shortcode ahead of the default scaip function and unregisters the default scaip function.
+If you wish to disable the shortcode that is inserted normally, in order to replace it with your own work, write a hook that hooks the shortcode ahead of the default scaip function (so, with priority number 9 or lower) that performs your desired output and then uses [`remove_action( 'scaip_shortcode', 'scaip_shortcode_do_sidebar', 10 )`](https://codex.wordpress.org/Function_Reference/remove_action) to remove the default SCAIP shortcode handler.
+
+If you wish to selectively disable programmatic shortcode insertion on a particular post, category of post, or other criteria, you can write a filter on `'scaip_whether_insert'`, accepting three parameters and returning `true` or `false`. The three parameters are:
+
+1. Bool $whether Whether to insert ads programmatically in this instance.
+2. String $content The post content.
+3. Mixed $queried_object `$wp_query->queried_object` in the context in which the programmatic shortcode inserter is running.
+
+An example filter would look like:
+
+```php
+function scaip_test_inserter_disabler( $whether, $content, $queried_object ) {
+	if ( isset( $queried_object->ID ) && 120 = $queried_object->ID ) {
+		return false;
+	}
+
+	return $whether;
+}
+add_filter( 'scaip_whether_insert', 'scaip_test_inserter_disabler', 10, 3 );

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Functions for the automatic insertion of scaip shortcodes
+ */
 
 /**
  * Adds the scaip shortcode to post after predetermined number of paragraphs
@@ -8,41 +11,11 @@
  * Some questions in this code, because Ad-Inserter doesn't have inline docs at all.
  *
  * @link https://plugins.trac.wordpress.org/browser/ad-inserter/trunk/ad-inserter.php#L1474
+ * @since 0.1
+ * @param String $content The post content.
+ * @return String The post content, plus shortcodes.
  */
 function scaip_insert_shortcode( $content = '' ) {
-	// Abort if this is not being called In The Loop.
-	if ( ! in_the_loop() || ! is_main_query() ) {
-		return $content;
-	}
-
-	// Abort if this is not a normal post.
-	global $wp_query;
-	if ( 'post' !== $wp_query->queried_object->post_type ) {
-		return $content;
-	}
-
-	/*
-	 * Abort if this post has the option set to not add ads.
-	 */
-	$skip = get_post_meta( $wp_query->queried_object->ID, 'scaip_prevent_shortcode_addition', true );
-	/*
-	 * Usually the meta field won't exist unless the checkbox to skip ads on any given post is checked.
-	 * An older version of the plugin saved it even when the box wasn't checked
-	 * so we need an extra check here for backwards compatibility.
-	 * the previous version saved the meta value as "on" if checked and empty if not.
-	 */
-	if ( ! empty( $skip ) || 'on' === $skip ) {
-		return $content;
-	}
-
-	/*
-	 * If we have a manual shortcode, bail.
-	 * (scaip was the older shortcode, retained here for backwards compatibility)
-	 */
-	if ( has_shortcode( $content, 'ad' ) || has_shortcode( $content, 'scaip' ) ) {
-		return $content;
-	}
-
 	$scaip_period = get_option( 'scaip_settings_period', 3 );
 	$scaip_repetitions = get_option( 'scaip_settings_repetitions', 2 );
 	$scaip_minimum_paragraphs = get_option( 'scaip_settings_min_paragraphs', 6 );
@@ -51,7 +24,7 @@ function scaip_insert_shortcode( $content = '' ) {
 	$last_position = -1;
 	$paragraph_end = '</p>';
 
-	// if we don't have an <p> tags, we probably need to apply wpautop().
+	// if we don't have any <p> tags, we probably need to apply wpautop().
 	if ( ! stripos( $content, $paragraph_end ) ) {
 		$content = wpautop( $content );
 	}
@@ -109,4 +82,63 @@ function scaip_insert_shortcode( $content = '' ) {
 	}
 	return $content;
 }
-add_filter( 'the_content', 'scaip_insert_shortcode', 10 );
+
+/**
+ * Function to determine whether to insert the shortcode
+ *
+ * @uses scaip_insert_shortcode
+ * @since 0.2
+ */
+function scaip_maybe_insert_shortcode( $content = '' ) {
+	// Abort if this is not being called In The Loop.
+	if ( ! in_the_loop() || ! is_main_query() ) {
+		return $content;
+	}
+
+	// Abort if this is not a normal post.
+	global $wp_query;
+	if ( 'post' !== $wp_query->queried_object->post_type ) {
+		return $content;
+	}
+
+	/*
+	 * Abort if this post has the option set to not add ads.
+	 */
+	$skip = get_post_meta( $wp_query->queried_object->ID, 'scaip_prevent_shortcode_addition', true );
+	/*
+	 * Usually the meta field won't exist unless the checkbox to skip ads on any given post is checked.
+	 * An older version of the plugin saved it even when the box wasn't checked
+	 * so we need an extra check here for backwards compatibility.
+	 * the previous version saved the meta value as "on" if checked and empty if not.
+	 */
+	if ( ! empty( $skip ) || 'on' === $skip ) {
+		return $content;
+	}
+
+	/*
+	 * If we have a manual shortcode, bail.
+	 * (scaip was the older shortcode, retained here for backwards compatibility)
+	 */
+	if ( has_shortcode( $content, 'ad' ) || has_shortcode( $content, 'scaip' ) ) {
+		return $content;
+	}
+
+	/*
+	 * Filter to determine whether to apply the shortcode to the given post content
+	 *
+	 * Filters on 'scaip_whether_insert' should accept three arguments, and return a boolean true or false. The default value is true: apply the filter. Use this filter to tell SCAIP to not programmatically insert the ad in this instance.
+	 *
+	 * @param Bool $whether Whether to insert ads programmatically in this instance.
+	 * @param String $content The post content.
+	 * @param Mixed $queried_object `$wp_query->queried_object` in the current context.
+	 *
+	 * @since 0.2
+	 * @link https://github.com/INN/super-cool-ad-inserter-plugin/issues/25
+	 */
+	if ( true !== apply_filters( 'scaip_whether_insert', true, $content, $wp_query->queried_object ) ) {
+		return $content;
+	}
+
+	return scaip_insert_shortcode( $content );
+}
+add_filter( 'the_content', 'scaip_maybe_insert_shortcode', 10 );

--- a/readme.txt
+++ b/readme.txt
@@ -17,15 +17,22 @@ This WordPress plugin gives site administrators a way to insert widgets such as 
 == Installation ==
 
 1. Upload the plugin directory to your `/wp-content/plugins/` directory
-1. Activate the plugin through the 'Plugins' menu in WordPress
+2. Activate the plugin through the 'Plugins' menu in WordPress
 
 For more advanced documentation for developers and advanced users see [the official plugin docs](https://github.com/INN/super-cool-ad-inserter-plugin/tree/master/docs).
 
 == Changelog ==
 
+= 0.2 =
+
+* Partial WordPress VIP code approval, via [Adam Schweigert](https://github.com/aschweigert)'s work in [pull request #32](https://github.com/INN/super-cool-ad-inserter-plugin/pull/32).
+* Adds filter to programmatically disable ad insertion. Pull request [#39](https://github.com/INN/super-cool-ad-inserter-plugin/pull/39) for [issue #25](https://github.com/INN/super-cool-ad-inserter-plugin/issues/25).
+* Improves compliance with WordPress.com VIP PHP code standards
+* Removes some unneeded development files
+
 = 0.1.2 =
 * Removes the .visuallyhidden class from the widget title of inserted widgets
-* Improves compliance with Wordpress PHP code standards
+* Improves compliance with WordPress PHP code standards
 * Removes some unneeded development files
 
 = 0.1 =

--- a/tests/inc/test-scaip-shortcode-inserter.php
+++ b/tests/inc/test-scaip-shortcode-inserter.php
@@ -12,4 +12,15 @@ class ScaipShortcodeInserterTestFunctions extends WP_UnitTestCase {
 		$this->markTestIncomplete( 'This test has not been implemented yet.' );
 	}
 
+	function test_scaip__maybe_insert_shortcode() {
+		// Check that it does nothing on posts outside The Loop
+		// check that the filter works
+		// check that it doesn't work on posts of other post tyles
+
+		$ret = scaip_maybe_insert_shortcode( '' );
+		$this->assertEquals( $ret, '' );
+
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
+	}
+
 }


### PR DESCRIPTION
## Changes

- Separates the functionality in the shortcode insertion function `scaip_insert_shortcode()` into two separate functions: insertion in `scaip_insert_shortcode()` and determination of whether to insert in `scaip_maybe_insert_shortcode()`
- Adds a filter for https://github.com/INN/super-cool-ad-inserter-plugin/issues/25 so that people may turn off insertion programmatically, and docs for same.

## Why

Resolves #25.