### PR TITLE
fix: correct plugin URI and links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ For detailed examples, ➡️  [read the docs!](./docs) ⬅️
 
 For a detailed changelog, [read readme.txt](./readme.txt)!
 
-For the most-recent release, [see the list of releases](https://github.com/Automattic/super-cool-adinserter-plugin/releases).
+For the most-recent release, [see the list of releases](https://github.com/Automattic/super-cool-ad-inserter-plugin/releases).
 
 Install the plugin [from the WordPress.org plugin repository](https://wordpress.org/plugins/super-cool-ad-inserter/).

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -1,5 +1,5 @@
 # Installation
 
-1. [Download this plugin](https://github.com/Automattic/super-cool-adinserter-plugin/archive/trunk.zip) and save it to your WordPress installation's `wp-content/plugins/` directory in a folder named `super-cool-ad-inserter-plugin`
+1. [Download this plugin](https://github.com/Automattic/super-cool-ad-inserter-plugin/archive/trunk.zip) and save it to your WordPress installation's `wp-content/plugins/` directory in a folder named `super-cool-ad-inserter-plugin`
 2. Follow the [manual plugin installation instructions](https://codex.wordpress.org/Managing_Plugins#Manual_Plugin_Installation) in the WordPress documentation to activate the plugin.
 3. [Configure the plugin](./configuration.md).

--- a/inc/scaip-metaboxes.php
+++ b/inc/scaip-metaboxes.php
@@ -33,7 +33,7 @@ function scaip_how_to_shortcode_callback() {
 	<p>
 		<?php
 		echo wp_kses(
-			__( 'If the automatic positioning causes problems for any given post, you can prevent automatic placement of the ads <a href="https://github.com/Automattic/super-cool-adinserter-plugin/blob/trunk/docs/display-settings.md">using a shortcode</a> or disable them completely by checking this box:', 'scaip' ),
+			__( 'If the automatic positioning causes problems for any given post, you can prevent automatic placement of the ads <a href="https://github.com/Automattic/super-cool-ad-inserter-plugin/blob/trunk/docs/display-settings.md">using a shortcode</a> or disable them completely by checking this box:', 'scaip' ),
 			array(
 				'a' => array(
 					'href' => array(),

--- a/inc/scaip-settings.php
+++ b/inc/scaip-settings.php
@@ -134,7 +134,7 @@ function scaip_admin_page() {
 			'<p>%1$s</p>',
 			sprintf(
 				__( 'For more information about these settings, and about the Super Cool Ad Inserter Plugin in general, <a href="%1$s">see the plugin\'s documentation on GitHub</a>.', 'scaip' ),
-				'https://github.com/Automattic/super-cool-adinserter-plugin/tree/trunk/docs'
+				'https://github.com/Automattic/super-cool-ad-inserter-plugin/tree/trunk/docs'
 			)
 		);
 		?>

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -217,7 +217,7 @@ function scaip_maybe_insert_shortcode( $content = '' ) {
 	 * @param Mixed $queried_object `$wp_query->queried_object` in the current context.
 	 *
 	 * @since 0.2
-	 * @link https://github.com/Automattic/super-cool-adinserter-plugin/issues/25
+	 * @link https://github.com/Automattic/super-cool-ad-inserter-plugin/issues/25
 	 */
 	if ( true !== apply_filters( 'scaip_whether_insert', true, $content, $wp_query->queried_object ) ) {
 		return $content;

--- a/super-cool-ad-inserter-plugin.php
+++ b/super-cool-ad-inserter-plugin.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Super Cool Ad Inserter Plugin
-Plugin URI: https://github.com/Automattic/super-cool-adinserter-plugin/tree/trunk/docs
+Plugin URI: https://github.com/Automattic/super-cool-ad-inserter-plugin/tree/trunk/docs
 Description: A simple way to insert widgets after the nth paragraph
 Version: 0.7.2
 Author: Automattic


### PR DESCRIPTION
This is causing things like the "Plugin Homepage" link to be broken.
<img width="498" height="277" alt="image" src="https://github.com/user-attachments/assets/5b2c3ab9-8afb-42d6-9085-e2f91f7b44ee" />
