### PR TITLE
chore: replace @abinoda/label-when-approved-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,105 @@
-on: pull_request_review
-name: Label approved pull requests
+on:
+  pull_request_review:
+    types: [submitted]
+name: Label pull requests on review
 jobs:
   labelWhenApproved:
     name: Label when approved
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - name: Label when approved
-        uses: pullreminders/label-when-approved-action@master
-        env:
-          APPROVALS: '1'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ADD_LABEL: '[Status] Approved'
-          # Needs to be URL-encoded, see https://github.com/abinoda/label-when-approved-action/pull/3#discussion_r321882620
-          REMOVE_LABEL: '%5BStatus%5D%20Needs%20Review'
+      - name: Check if review is approved
+        id: check_approval
+        run: |
+          if [ "${{ github.event.review.state }}" = "approved" ]; then
+            echo "approved=true" >> $GITHUB_OUTPUT
+          else
+            echo "approved=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add approved label
+        if: steps.check_approval.outputs.approved == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo, number } = context.issue;
+
+            // Add the approved label
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: number,
+              labels: ['[Status] Approved']
+            });
+
+            // Remove the needs review label if it exists
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: number,
+                name: '[Status] Needs Review'
+              });
+            } catch (error) {
+              // Label might not exist, which is fine
+              console.log('Label "[Status] Needs Review" not found or already removed');
+            }
+
+            // Remove the needs changes or feedback label if it exists
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: number,
+                name: '[Status] Needs Changes or Feedback'
+              });
+            } catch (error) {
+              // Label might not exist, which is fine
+              console.log('Label "[Status] Needs Changes or Feedback" not found or already removed');
+            }
+
+  labelWhenChangesRequested:
+    name: Label when changes requested
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check if review requests changes
+        id: check_changes_requested
+        run: |
+          if [ "${{ github.event.review.state }}" = "changes_requested" ]; then
+            echo "changes_requested=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes_requested=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add changes requested label
+        if: steps.check_changes_requested.outputs.changes_requested == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo, number } = context.issue;
+
+            // Add the changes requested label
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: number,
+              labels: ['[Status] Needs Changes or Feedback']
+            });
+
+            // Remove the approved label if it exists
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: number,
+                name: '[Status] Approved'
+              });
+            } catch (error) {
+              // Label might not exist, which is fine
+              console.log('Label "[Status] Approved" not found or already removed');
+            }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a failing workflow job due to a repository that is no longer public. Example: https://github.com/Automattic/newspack-plugin/actions/runs/17559433368/job/49871807949

See https://github.com/Automattic/newspack-plugin/pull/4182

### How to test the changes in this Pull Request:

1. Review the code
2. Submit a code review requesting changes and confirm that the "[Status] Needs Review" label is removed, and the "[Status] Needs Changes or Feedback" label is added
3. Submit a code review with approval and confirm that the "[Status] Needs Changes or Feedback" label is removed and "[Status] Approved" is added

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->