### PR TITLE
fix: update blocks to support iframe-based Post Editor

### DIFF
--- a/blocks/scaip-sidebar.php
+++ b/blocks/scaip-sidebar.php
@@ -28,6 +28,7 @@ function scaip_sidebar_block_init() {
 			'wp-i18n',
 			'wp-element',
 			'wp-components',
+			'wp-block-editor',
 		),
 		filemtime( "$dir/$block_js" ),
 		true
@@ -50,6 +51,7 @@ function scaip_sidebar_block_init() {
 	register_block_type(
 		'super-cool-ad-inserter-plugin/scaip-sidebar',
 		array(
+			'api_version'     => 3,
 			'editor_script'   => 'scaip-sidebar-block-editor',
 			'editor_style'    => 'scaip-sidebar-block-editor',
 			'style'           => 'scaip-sidebar-block',

--- a/blocks/scaip-sidebar/block.js
+++ b/blocks/scaip-sidebar/block.js
@@ -133,7 +133,7 @@
 						),
 						label: __( 'Inserted Ad Position Sidebar' ),
 						notices: notices,
-						instructions: ! notices.length ? __( 'Which Inserted Ad Position sidebar should be displayed in this area? ' ) : null
+						instructions: ! notices.length ? __( 'Which Inserted Ad Position sidebar should be displayed in this area?' ) : null
 					},
 					! notices.length && el(
 						ExternalLink,

--- a/blocks/scaip-sidebar/block.js
+++ b/blocks/scaip-sidebar/block.js
@@ -131,17 +131,15 @@
 							),
 							label: __( 'Inserted Ad Position Sidebar' ),
 							notices: notices,
-							instructions: ! notices.length ? [
-								__( 'Which Inserted Ad Position sidebar should be displayed in this area? ' ), // trailing space is important.
-								el(
-									ExternalLink,
-									{
-										href: 'https://github.com/Automattic/super-cool-ad-inserter-plugin/blob/trunk/docs/configuration.md'
-									},
-									'View the documentation.'
-								)
-							] : null
+							instructions: ! notices.length ? __( 'Which Inserted Ad Position sidebar should be displayed in this area? ' ) : null
 						},
+						! notices.length && el(
+							ExternalLink,
+							{
+								href: 'https://github.com/Automattic/super-cool-ad-inserter-plugin/blob/trunk/docs/configuration.md'
+							},
+							'View the documentation.'
+						),
 						! window.scaip.sidebar_disabled && el(
 							SelectControl,
 							{

--- a/blocks/scaip-sidebar/block.js
+++ b/blocks/scaip-sidebar/block.js
@@ -94,7 +94,6 @@
 			for ( var i = 1; i <= window.scaip.repetitions; i += 1 ) {
 				options_array.push( {
 					label: i.toString(),
-					key: i.toString(),
 					value: i.toString()
 				} );
 			}

--- a/blocks/scaip-sidebar/block.js
+++ b/blocks/scaip-sidebar/block.js
@@ -40,10 +40,16 @@
 	 */
 	var dashicon = wp.components.Dashicon;
 	/**
+	 * Hook to mark the block wrapper element for apiVersion 3 / iframe editor compatibility.
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/
+	 */
+	var useBlockProps = wp.blockEditor.useBlockProps;
+	/**
 	 * Every block starts by registering a new block type definition.
 	 * @see https://wordpress.org/gutenberg/handbook/block-api/
 	 */
 	registerBlockType( 'super-cool-ad-inserter-plugin/scaip-sidebar', {
+		apiVersion: 3,
 		title: __( 'Inserted Ad Position Sidebar' ),
 		icon: 'welcome-widgets-menus',
 		category: 'widgets',
@@ -71,8 +77,10 @@
 		 * @return {Element}       Element to render.
 		 */
 		edit: function( props ) {
+			var blockProps = useBlockProps();
+
 			if ( ! window.scaip ) {
-				return "Something is wrong with the Super Cool Ad Inserter Plugin.";
+				return el( 'div', blockProps, "Something is wrong with the Super Cool Ad Inserter Plugin." );
 			}
 
 			var options_array = [] ;
@@ -112,52 +120,46 @@
 				);
 			}
 
-
-			return [
+			return el(
+				'div',
+				blockProps,
 				el(
-					'div',
+					Placeholder,
 					{
-						className: props.className,
-						align: props.align
-					},
-					el(
-						Placeholder,
-						{
-							icon: el(
-								dashicon,
-								{
-									icon: 'welcome-widgets-menus'
-								}
-							),
-							label: __( 'Inserted Ad Position Sidebar' ),
-							notices: notices,
-							instructions: ! notices.length ? __( 'Which Inserted Ad Position sidebar should be displayed in this area? ' ) : null
-						},
-						! notices.length && el(
-							ExternalLink,
+						icon: el(
+							dashicon,
 							{
-								href: 'https://github.com/Automattic/super-cool-ad-inserter-plugin/blob/trunk/docs/configuration.md'
-							},
-							'View the documentation.'
+								icon: 'welcome-widgets-menus'
+							}
 						),
-						! window.scaip.sidebar_disabled && el(
-							SelectControl,
-							{
-								label: __( 'Inserted Ad Position:' ),
-								labelPosition: 'top',
-								hideLabelFromVision: true,
-								options: options_array,
-								value: value,
-								onChange: function( value ) {
-									if ( value > 0 ) {
-										props.setAttributes( { number: value.toString() } );
-									}
+						label: __( 'Inserted Ad Position Sidebar' ),
+						notices: notices,
+						instructions: ! notices.length ? __( 'Which Inserted Ad Position sidebar should be displayed in this area? ' ) : null
+					},
+					! notices.length && el(
+						ExternalLink,
+						{
+							href: 'https://github.com/Automattic/super-cool-ad-inserter-plugin/blob/trunk/docs/configuration.md'
+						},
+						'View the documentation.'
+					),
+					! window.scaip.sidebar_disabled && el(
+						SelectControl,
+						{
+							label: __( 'Inserted Ad Position:' ),
+							labelPosition: 'top',
+							hideLabelFromVision: true,
+							options: options_array,
+							value: value,
+							onChange: function( value ) {
+								if ( value > 0 ) {
+									props.setAttributes( { number: value.toString() } );
 								}
 							}
-						)
+						}
 					)
 				)
-			];
+			);
 		},
 
 		/**
@@ -165,22 +167,13 @@
 		 * into the final markup, which is then serialized by Gutenberg into `post_content`.
 		 * @see https://wordpress.org/gutenberg/handbook/block-edit-save/#save
 		 *
-		 * Because this is a dynamic block, there's nothing returned here.
-		 * Yet, because this dynamic block draws from the attributes saved for its blockself
-		 * in the post_content, we must return *something* in order for the attributes
-		 * to be saved in the post.
+		 * This is a dynamic block rendered by the scaip_sidebar_block_render PHP callback.
+		 * Returning null produces a self-closing block delimiter in post_content.
 		 *
-		 * Can't use https://developer.mozilla.org/en-US/docs/Web/API/Comment/Comment because
-		 * that constructor isn't supported in IE.
-		 *
-		 * Therefore, use https://developer.mozilla.org/en-US/docs/Web/API/Document/createComment because
-		 * that particular function has been around since 2000: https://www.w3.org/TR/2000/WD-DOM-Level-1-20000929/level-one-core.html#ID-1334481328
-		 *
-		 * @return {Element}       Element to render.
+		 * @return {null} Null because rendering is handled server-side.
 		 */
-		save: function( attributes ) {
-			// Rendering in PHP
-			return document.createComment( attributes );
+		save: function() {
+			return null;
 		}
 	} );
 } )(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reworks a block in this plugin for compatibility with the new iframe-based Post Editor:

* super-cool-ad-inserter-plugin/scaip-sidebar

Addresses [NPPM-2587: Super Cool Ad Inserter Plugin (iframe Editor Compatibility)](https://linear.app/a8c/issue/NPPM-2587/super-cool-ad-inserter-plugin-iframe-editor-compatibility).

### How to test the changes in this Pull Request:

#### Prerequisites:

1. Set up a basic test site with only `newspack-plugin` and this plugin enabled.
2. Visit the Widget Settings and add some test content to `Inserted Ad Position 1` and `Inserted Ad Position 2`.
3. Create and save a test post or posts that uses the following block:
  * Inserted Ad Position Sidebar
4. Verify the sidebar selector for the Inserted Ad Position Sidebar block works.
5. Verify changes to the sidebar selection are reflected in the underlying HTML placeholder.
4. Verify these blocks show up as expected outside the editor.
6. Check the rendered page structure to make sure you're viewing the non-iframe editor--none of the ancestors of the block elements should be an `<iframe>`.

#### Testing newly-created blocks:
1. Apply this PR.
3. Create a new post.
4. Verify you're in the iframe editor by checking the page structure--you should see an iframe wrapping the edit pane.
5. Add the Inserted Ad Position Sidebar block:
  a. Does the block show up in the editor?
  b. Does the sidebar selector work?
  c. Are changes to that selector reflected in the underlying HTML placeholder?
  d. Does the block render when viewing the post outside the editor?
 
#### Testing existing blocks (the upgrade case):
1. Apply this PR if you haven't already.
2. View the posts you created before applying the PR.
3. Do the existing blocks continue to work as expected?
4. Is the same true when viewing the post outside the editor?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->