### PR TITLE
ci: fix dependabot auto-merge for grouped updates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,18 +1,63 @@
 on:
   pull_request_target:
-    types: [labeled]
 
 name: Dependabot auto-merge
 jobs:
   auto-merge:
     name: Auto-merge dependabot PRs for minor and patch updates
     runs-on: ubuntu-latest
-    if: |
-      contains( github.event.pull_request.labels.*.name, 'dependencies' )
-      && ! contains( github.event.pull_request.labels.*.name, '[Status] Approved' )
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
         with:
-          target: minor # includes patch updates.
-          github-token: ${{ secrets.DEPENDABOT_TOKEN }}
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Check for major version bumps in PR body
+        if: steps.metadata.outputs.update-type == ''
+        id: check-major
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Parse "from X to Y" version pairs from the PR body and flag major bumps.
+          HAS_MAJOR=false
+          while IFS= read -r line; do
+            from_ver=$(echo "$line" | sed -n 's/.*from \([0-9][0-9.]*\) to \([0-9][0-9.]*\).*/\1/p')
+            to_ver=$(echo "$line" | sed -n 's/.*from \([0-9][0-9.]*\) to \([0-9][0-9.]*\).*/\2/p')
+            [ -z "$from_ver" ] && continue
+            from_major="${from_ver%%.*}"
+            to_major="${to_ver%%.*}"
+            if [ "$from_major" != "$to_major" ]; then
+              echo "Major bump detected: $from_ver -> $to_ver"
+              HAS_MAJOR=true
+            fi
+          done <<< "$PR_BODY"
+          echo "has_major=$HAS_MAJOR" >> "$GITHUB_OUTPUT"
+
+      - name: Approve PR
+        if: >-
+          ((contains(steps.metadata.outputs.update-type, 'version-update:semver-minor') ||
+          contains(steps.metadata.outputs.update-type, 'version-update:semver-patch')) &&
+          !contains(steps.metadata.outputs.update-type, 'version-update:semver-major')) ||
+          (steps.metadata.outputs.update-type == '' &&
+          steps.check-major.outputs.has_major != 'true')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: >-
+          ((contains(steps.metadata.outputs.update-type, 'version-update:semver-minor') ||
+          contains(steps.metadata.outputs.update-type, 'version-update:semver-patch')) &&
+          !contains(steps.metadata.outputs.update-type, 'version-update:semver-major')) ||
+          (steps.metadata.outputs.update-type == '' &&
+          steps.check-major.outputs.has_major != 'true')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces the deprecated `ahmadnassri/action-dependabot-auto-merge@v2` with `dependabot/fetch-metadata@v2`
- Adds version parsing fallback for grouped multi-dependency PRs where `fetch-metadata` doesn't populate `update-type`
- Parses PR body for `from X to Y` version patterns and blocks auto-merge if any dependency has a major bump

Same change as Automattic/newspack-plugin#4599 and 14 other Newspack repos.