### PR TITLE
fix: replace classic metabox with block editor sidebar panel

### DIFF
--- a/assets/js/scaip-document-panel.js
+++ b/assets/js/scaip-document-panel.js
@@ -1,0 +1,69 @@
+( function ( wp ) {
+	var __ = wp.i18n.__;
+	var sprintf = wp.i18n.sprintf;
+	var el = wp.element.createElement;
+	var registerPlugin = wp.plugins.registerPlugin;
+	var domReady = wp.domReady;
+	// PluginDocumentSettingPanel moved from wp.editPost to wp.editor in WP 6.6+.
+	// Fall back to wp.editPost for older Gutenberg versions.
+	var PluginDocumentSettingPanel =
+		( wp.editor && wp.editor.PluginDocumentSettingPanel ) ||
+		( wp.editPost && wp.editPost.PluginDocumentSettingPanel );
+	var CheckboxControl = wp.components.CheckboxControl;
+	var useEntityProp = wp.coreData.useEntityProp;
+	var useSelect = wp.data.useSelect;
+
+	function ScaipDocumentPanel() {
+		var postType = useSelect( function ( select ) {
+			return select( 'core/editor' ).getCurrentPostType();
+		}, [] );
+
+		// Both hooks must be called unconditionally before any early return
+		// (React Rules of Hooks). useEntityProp tolerates undefined postType.
+		var entityProp = useEntityProp( 'postType', postType, 'meta' );
+		var meta = entityProp[ 0 ] || {};
+		var setMeta = entityProp[ 1 ];
+
+		// The classic metabox is registered only on 'post'; mirror that here.
+		if ( postType !== 'post' ) {
+			return null;
+		}
+
+		var settings = window.scaipDocumentPanel || {};
+
+		// Mirrors the classic metabox copy in scaip_how_to_shortcode_callback().
+		var description = sprintf(
+			/* translators: 1: number of ads inserted, 2: blocks before first insertion, 3: blocks between insertions, 4: minimum paragraphs required. */
+			__( 'By default, %1$s ads will be inserted in a post, beginning %2$s blocks after the beginning and every %3$s paragraphs after that. They will not appear if this post is shorter than %4$s paragraphs long.', 'scaip' ),
+			settings.repetitions,
+			settings.start,
+			settings.period,
+			settings.minimum_paragraphs
+		);
+
+		return el(
+			PluginDocumentSettingPanel,
+			{
+				name: 'scaip-document-panel',
+				title: __( 'Super Cool Ad Inserter', 'scaip' ),
+			},
+			el( 'p', null, description ),
+			el( CheckboxControl, {
+				label: __( 'Prevent automatic addition of ads to this post.', 'scaip' ),
+				checked: !! meta.scaip_prevent_shortcode_addition,
+				onChange: function ( value ) {
+					setMeta( { scaip_prevent_shortcode_addition: value } );
+				},
+			} )
+		);
+	}
+
+	// Defer registration so this panel renders after panels registered
+	// synchronously by other plugins, pushing it toward the bottom of the
+	// document settings sidebar.
+	domReady( function () {
+		registerPlugin( 'scaip-document-panel', {
+			render: ScaipDocumentPanel,
+		} );
+	} );
+} )( window.wp );

--- a/assets/js/scaip-document-panel.js
+++ b/assets/js/scaip-document-panel.js
@@ -31,7 +31,8 @@
 
 		var settings = window.scaipDocumentPanel || {};
 
-		// Mirrors the classic metabox copy in scaip_how_to_shortcode_callback().
+		// Settings come from window.scaipDocumentPanel, localized in
+		// scaip_enqueue_document_panel_assets() (inc/scaip-metaboxes.php).
 		var description = sprintf(
 			/* translators: 1: number of ads inserted, 2: blocks before first insertion, 3: blocks between insertions, 4: minimum paragraphs required. */
 			__( 'By default, %1$s ads will be inserted in a post, beginning %2$s blocks after the beginning and every %3$s paragraphs after that. They will not appear if this post is shorter than %4$s paragraphs long.', 'scaip' ),

--- a/inc/scaip-metaboxes.php
+++ b/inc/scaip-metaboxes.php
@@ -11,42 +11,56 @@
 /**
  * Auth callback used by register_post_meta for scaip_prevent_shortcode_addition.
  *
- * Anyone who can edit the post can toggle this meta via the REST API. This
- * matches the gating other Newspack-managed editor panels (ads, campaigns) use.
+ * Only users who can edit_others_posts may toggle this meta via the REST API.
+ * This matches the capability the original classic metabox required.
  *
  * @param bool   $allowed   Whether the user can edit the meta. Unused; we make
  *                          the determination ourselves.
  * @param string $meta_key  The meta key being modified. Unused.
- * @param int    $object_id The post being modified.
+ * @param int    $object_id The post being modified. Unused; the cap is global.
  * @param int    $user_id   The user attempting to write the meta.
  * @return bool Whether the write should be permitted.
  */
 function scaip_prevent_shortcode_addition_auth_callback( $allowed, $meta_key, $object_id, $user_id ) {
-	return user_can( $user_id, 'edit_post', $object_id );
+	return user_can( $user_id, 'edit_others_posts' );
 }
 
-register_post_meta(
-	'post',
-	'scaip_prevent_shortcode_addition',
-	array(
-		'type'          => 'boolean',
-		'single'        => true,
-		'show_in_rest'  => true,
-		'default'       => false,
-		'auth_callback' => 'scaip_prevent_shortcode_addition_auth_callback',
-	)
-);
+/**
+ * Registers the scaip_prevent_shortcode_addition post meta.
+ *
+ * Hooked on init per WordPress's recommended timing for register_post_meta;
+ * earlier registration can run before REST schema infrastructure is ready.
+ */
+function scaip_register_prevent_shortcode_addition_meta() {
+	register_post_meta(
+		'post',
+		'scaip_prevent_shortcode_addition',
+		array(
+			'type'          => 'boolean',
+			'single'        => true,
+			'show_in_rest'  => true,
+			'default'       => false,
+			'auth_callback' => 'scaip_prevent_shortcode_addition_auth_callback',
+		)
+	);
+}
+add_action( 'init', 'scaip_register_prevent_shortcode_addition_meta' );
 
 /**
  * Enqueues the SCAIP document settings panel script in the block editor.
  *
- * Skips if the current screen isn't the block editor for a post. WordPress
- * already gates editor access on edit_post; the auth_callback above gates
- * REST writes, so no extra cap check is needed here.
+ * Skips if the current screen isn't the block editor for a post, or if the
+ * user lacks edit_others_posts — the panel JS is never sent to clients that
+ * can't use it. This matches the capability the original classic metabox
+ * required.
  */
 function scaip_enqueue_document_panel_assets() {
 	$screen = get_current_screen();
 	if ( ! $screen || ! $screen->is_block_editor() || 'post' !== $screen->id ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'edit_others_posts' ) ) {
 		return;
 	}
 

--- a/inc/scaip-metaboxes.php
+++ b/inc/scaip-metaboxes.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * A metabox that explains how many ads are inserted and where as well as how to override the default behavior on a per-post basis.
+ * Registers the scaip_prevent_shortcode_addition post meta and the block-editor
+ * sidebar panel that toggles it on a per-post basis.
  *
  * @package WordPress
  * @subpackage SCAIP
@@ -8,111 +9,81 @@
  */
 
 /**
- * Generate the contents of the metabox.
+ * Auth callback used by register_post_meta for scaip_prevent_shortcode_addition.
+ *
+ * Anyone who can edit the post can toggle this meta via the REST API. This
+ * matches the gating other Newspack-managed editor panels (ads, campaigns) use.
+ *
+ * @param bool   $allowed   Whether the user can edit the meta. Unused; we make
+ *                          the determination ourselves.
+ * @param string $meta_key  The meta key being modified. Unused.
+ * @param int    $object_id The post being modified.
+ * @param int    $user_id   The user attempting to write the meta.
+ * @return bool Whether the write should be permitted.
  */
-function scaip_how_to_shortcode_callback() {
-	global $post;
-
-	$scaip_start = get_option( 'scaip_settings_start', 3 );
-	$scaip_period = get_option( 'scaip_settings_period', 3 );
-	$scaip_repetitions = get_option( 'scaip_settings_repetitions', 2 );
-	$scaip_minimum_paragraphs = get_option( 'scaip_settings_min_paragraphs', 6 );
-	wp_nonce_field( 'scaip_metabox', 'scaip_metabox_nonce' );
-	?>
-	<p>
-		<?php
-			printf(
-				// translators: %1$s is the number of ads that will be inserted, %2$s is the number of blocks before the first insertion, %3$s is the number of blocks between insertions, %4$s is the number of paragraphs required for the ads to appear.
-				esc_html__( 'By default, %1$s ads will be inserted in a post, beginning %2$s blocks after the beginning and every %3$s paragraphs after that. They will not appear if this post is shorter than %4$s paragraphs long.', 'scaip' ),
-				esc_html( $scaip_repetitions ),
-				esc_html( $scaip_start ),
-				esc_html( $scaip_period ),
-				esc_html( $scaip_minimum_paragraphs )
-			);
-		?>
-	</p>
-	<p>
-		<?php
-		echo wp_kses(
-			__( 'If the automatic positioning causes problems for any given post, you can prevent automatic placement of the ads <a href="https://github.com/Automattic/super-cool-ad-inserter-plugin/blob/trunk/docs/display-settings.md">using a shortcode</a> or disable them completely by checking this box:', 'scaip' ),
-			array(
-				'a' => array(
-					'href' => array(),
-				),
-			)
-		);
-		?>
-	</p>
-	<?php
-	if ( current_user_can( 'edit_others_posts' ) ) {
-		$checked = get_post_meta( $post->ID, 'scaip_prevent_shortcode_addition', true );
-		echo '<p><label class="selectit"><input type="checkbox" value="true" name="scaip_prevent_shortcode_addition"' . checked( $checked, 1, false ) . '> ' . esc_html__( 'Prevent automatic addition of ads to this post.', 'scaip' ) . '</label></p>';
-	}
+function scaip_prevent_shortcode_addition_auth_callback( $allowed, $meta_key, $object_id, $user_id ) {
+	return user_can( $user_id, 'edit_post', $object_id );
 }
 
-// Only register the meta box if the user is an editor or greater.
-add_action(
-	'add_meta_boxes',
-	function() {
-		if ( current_user_can( 'edit_others_posts' ) ) {
-			add_meta_box( 'scaip_docs_and_options', __( 'Super Cool Ad Inserter', 'scaip' ), 'scaip_how_to_shortcode_callback', 'post', 'normal', 'low' );
-		}
-	}
+register_post_meta(
+	'post',
+	'scaip_prevent_shortcode_addition',
+	array(
+		'type'          => 'boolean',
+		'single'        => true,
+		'show_in_rest'  => true,
+		'default'       => false,
+		'auth_callback' => 'scaip_prevent_shortcode_addition_auth_callback',
+	)
 );
 
-// But always register the meta.
-register_meta( 'post', 'scaip_prevent_shortcode_addition', array( 'sanitize_callback' => 'scaip_prevent_shortcode_addition_sanitize' ) );
-
 /**
- * Sanitization callback for saving the scaip_prevent_shortcode_addition post meta option.
+ * Enqueues the SCAIP document settings panel script in the block editor.
  *
- * @param array $args the callback args.
+ * Skips if the current screen isn't the block editor for a post. WordPress
+ * already gates editor access on edit_post; the auth_callback above gates
+ * REST writes, so no extra cap check is needed here.
  */
-function scaip_prevent_shortcode_addition_sanitize( $args ) {
-	$args = sanitize_text_field( $args );
-	if ( 1 === intval( $args ) ) {
-		$ret = $args;
-	} else {
-		$ret = false;
-	}
-
-	return $ret;
-}
-
-/**
- * Save the options set in the metabox.
- *
- * @param int    $post_id the post ID.
- * @param object $post the post object.
- */
-function _scaip_meta_box_save( $post_id, $post ) {
-
-	// Verify the nonce before proceeding.
-	$nonce = isset( $_POST['scaip_metabox_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['scaip_metabox_nonce'] ) ) : '';
-	if ( ! $nonce || ! wp_verify_nonce( $nonce, 'scaip_metabox' ) ) {
-		return false;
-	}
-
-	// Bail if we're doing an auto save.
-	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+function scaip_enqueue_document_panel_assets() {
+	$screen = get_current_screen();
+	if ( ! $screen || ! $screen->is_block_editor() || 'post' !== $screen->id ) {
 		return;
 	}
 
-	// If our current user can't edit this post, bail.
-	if ( ! current_user_can( 'edit_post', $post->ID ) ) {
-		return;
-	}
+	$plugin_dir = plugin_dir_path( SCAIP_PLUGIN_FILE );
+	$plugin_url = plugin_dir_url( SCAIP_PLUGIN_FILE );
+	$panel_path = 'assets/js/scaip-document-panel.js';
 
-	$new_meta_value = ( isset( $_POST['scaip_prevent_shortcode_addition'] ) ? sanitize_html_class( wp_unslash( $_POST['scaip_prevent_shortcode_addition'] ) ) : '' );
+	wp_enqueue_script(
+		'scaip-document-panel',
+		$plugin_url . $panel_path,
+		array(
+			'wp-plugins',
+			// Both wp-editor and wp-edit-post are required: panel.js falls back
+			// from wp.editor.PluginDocumentSettingPanel (WP 6.6+) to
+			// wp.editPost.PluginDocumentSettingPanel (older versions).
+			'wp-editor',
+			'wp-edit-post',
+			'wp-element',
+			'wp-components',
+			'wp-i18n',
+			'wp-core-data',
+			'wp-data',
+			'wp-dom-ready',
+		),
+		filemtime( $plugin_dir . $panel_path ),
+		true
+	);
 
-	/*
-	 * If the checkbox was checked, update the meta_value
-	 * If the checkbox was unchecked, delete the meta_value
-	 */
-	if ( ! empty( $new_meta_value ) ) {
-		add_post_meta( $post_id, 'scaip_prevent_shortcode_addition', 1, true );
-	} else {
-		delete_post_meta( $post_id, 'scaip_prevent_shortcode_addition' );
-	}
+	wp_localize_script(
+		'scaip-document-panel',
+		'scaipDocumentPanel',
+		array(
+			'start'              => get_option( 'scaip_settings_start', 3 ),
+			'period'             => get_option( 'scaip_settings_period', 3 ),
+			'repetitions'        => get_option( 'scaip_settings_repetitions', 2 ),
+			'minimum_paragraphs' => get_option( 'scaip_settings_min_paragraphs', 6 ),
+		)
+	);
 }
-add_action( 'save_post', '_scaip_meta_box_save', 10, 2 );
+add_action( 'enqueue_block_editor_assets', 'scaip_enqueue_document_panel_assets' );

--- a/inc/scaip-metaboxes.php
+++ b/inc/scaip-metaboxes.php
@@ -36,11 +36,12 @@ function scaip_register_prevent_shortcode_addition_meta() {
 		'post',
 		'scaip_prevent_shortcode_addition',
 		array(
-			'type'          => 'boolean',
-			'single'        => true,
-			'show_in_rest'  => true,
-			'default'       => false,
-			'auth_callback' => 'scaip_prevent_shortcode_addition_auth_callback',
+			'type'              => 'boolean',
+			'single'            => true,
+			'show_in_rest'      => true,
+			'default'           => false,
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'auth_callback'     => 'scaip_prevent_shortcode_addition_auth_callback',
 		)
 	);
 }

--- a/tests/inc/test-scaip-metaboxes.php
+++ b/tests/inc/test-scaip-metaboxes.php
@@ -15,38 +15,36 @@
 class ScaipMetaboxesTestFunctions extends WP_UnitTestCase {
 
 	/**
-	 * An Author can edit their own posts, so the meta auth callback must
-	 * allow REST writes for a post they authored.
+	 * Authors do not have edit_others_posts, so the meta auth callback
+	 * must reject their REST writes.
 	 */
-	public function test_auth_callback_allows_author_on_own_post() {
+	public function test_auth_callback_denies_users_without_edit_others_posts() {
 		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$post_id   = $this->factory->post->create( array( 'post_author' => $author_id ) );
 
 		$result = scaip_prevent_shortcode_addition_auth_callback(
 			false,
 			'scaip_prevent_shortcode_addition',
-			$post_id,
+			0,
 			$author_id
 		);
 
-		$this->assertTrue( $result );
+		$this->assertFalse( $result );
 	}
 
 	/**
-	 * Subscribers cannot edit any post, so the meta auth callback must
-	 * deny their REST writes.
+	 * Editors have edit_others_posts, so the meta auth callback must
+	 * allow their REST writes.
 	 */
-	public function test_auth_callback_denies_subscriber() {
-		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
-		$post_id       = $this->factory->post->create();
+	public function test_auth_callback_allows_users_with_edit_others_posts() {
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 
 		$result = scaip_prevent_shortcode_addition_auth_callback(
 			false,
 			'scaip_prevent_shortcode_addition',
-			$post_id,
-			$subscriber_id
+			0,
+			$editor_id
 		);
 
-		$this->assertFalse( $result );
+		$this->assertTrue( $result );
 	}
 }

--- a/tests/inc/test-scaip-metaboxes.php
+++ b/tests/inc/test-scaip-metaboxes.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for the SCAIP metaboxes / sidebar panel module.
+ *
+ * @package super-cool-ad-inserter-plugin
+ */
+
+/**
+ * Test the auth callback used by register_post_meta for
+ * scaip_prevent_shortcode_addition.
+ *
+ * The function under test, scaip_prevent_shortcode_addition_auth_callback(),
+ * is defined in inc/scaip-metaboxes.php.
+ */
+class ScaipMetaboxesTestFunctions extends WP_UnitTestCase {
+
+	/**
+	 * An Author can edit their own posts, so the meta auth callback must
+	 * allow REST writes for a post they authored.
+	 */
+	public function test_auth_callback_allows_author_on_own_post() {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$post_id   = $this->factory->post->create( array( 'post_author' => $author_id ) );
+
+		$result = scaip_prevent_shortcode_addition_auth_callback(
+			false,
+			'scaip_prevent_shortcode_addition',
+			$post_id,
+			$author_id
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Subscribers cannot edit any post, so the meta auth callback must
+	 * deny their REST writes.
+	 */
+	public function test_auth_callback_denies_subscriber() {
+		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$post_id       = $this->factory->post->create();
+
+		$result = scaip_prevent_shortcode_addition_auth_callback(
+			false,
+			'scaip_prevent_shortcode_addition',
+			$post_id,
+			$subscriber_id
+		);
+
+		$this->assertFalse( $result );
+	}
+}


### PR DESCRIPTION
SCAIP includes a post meta box, which is causing WordPress 7.0's real time collaboration not to work. 

This PR updates the post meta box to move it to the Gutenberg sidebar. 

It also fully removes the original post meta box. This means the option no longer appears in the Classic Editor. I opted to do this because the option wasn't saving in the Classic Editor on trunk or the latest release, even with no Newspack plugins installed, and the issue has not been reported in GitHub or the WordPress.org support forum. If there are any concerns about this move please let me know!

Note that this panel is redundant when paired with Newspack Ads, since it has a separate visibility control to show/hide individual SCAIP placement. I made a separate PR to hide this new panel outright when Newspack Ads is enabled here: https://github.com/Automattic/newspack-ads/pull/1064

## Steps to test

### Testing the toggle

1. Apply the PR.
2. Confirm you have a Super Cool Ad Inserter panel in the sidebar of the post editor.
3. Assuming https://github.com/Automattic/newspack-ads/pull/1064 has not been merged, set up ads, and set up some in post placements. Ensure they are showing on the front-end. 
4. Edit a post and toggle on 'Prevent automatic addition of ads to this post.' Save and refresh the post, and ensure the editor option stays on.
5. View on the front-end and ensure the ads are no longer loading. 
6. Edit the post and toggle back off and save.
7. View on the front-end and ensure ads are loading again.
8. To match how the post meta box originally worked, it was limited to users with `edit_others_posts` capabilities. To test this, first deactivate Co-Authors Plus (which messes with the capabilities).
9. Switch to a user that's an 'Author'.
10. Create a new post.
11. Confirm there's no Super Cool Ad Inserter panel in the sidebar.

### Testing RTC

1. On a site running the latest WP 7.0 RC, navigate to Settings > Writing and enable the experimental real-time collaboration feature. 
2. Open a post in a browser window.
3. In a separate incognito window, open the same post as a different user and try to edit it. 
4. Confirm you don't get this warning. Note that other plugins can cause this warning (like Yoast) so you may need to deactivate non-Newspack plugins to ensure it's working.

<img width="556" height="367" alt="image" src="https://github.com/user-attachments/assets/39d85030-484b-48a7-ae6d-cfdaed0b3e52" />
